### PR TITLE
 fix: format Rspack error stack

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import supportsColor from 'supports-color';
 // https://github.com/chalk/supports-color
 export const colorLevel = supportsColor.stdout ? supportsColor.stdout.level : 0;
 
-let errorStackRegExp = /^\s*at\s.*:\d+:\d+[\s)]*$/;
+let errorStackRegExp = /at\s.*:\d+:\d+[\s\)]*$/;
 let anonymousErrorStackRegExp = /^\s*at\s.*\(<anonymous>\)$/;
 
 export let isErrorStackMessage = (message: string) =>

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -22,10 +22,6 @@ describe('isErrorStackMessage', () => {
       isErrorStackMessage('    at transform.next (<anonymous>)'),
     ).toBeTruthy();
 
-    expect(
-      isErrorStackMessage('    │ (from: /rslog/packages/foo/loader.js)'),
-    ).toBeTruthy();
-
     expect(isErrorStackMessage('    at Array.map (<anonymous>)')).toBeTruthy();
 
     expect(

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -22,6 +22,10 @@ describe('isErrorStackMessage', () => {
       isErrorStackMessage('    at transform.next (<anonymous>)'),
     ).toBeTruthy();
 
+    expect(
+      isErrorStackMessage('    │ (from: /rslog/packages/foo/loader.js)'),
+    ).toBeTruthy();
+
     expect(isErrorStackMessage('    at Array.map (<anonymous>)')).toBeTruthy();
 
     expect(


### PR DESCRIPTION
Fix Rspack error stack is not formatted in some cases.

<img width="1233" alt="Screenshot 2024-01-30 at 21 48 50" src="https://github.com/rspack-contrib/rslog/assets/7237365/76596267-e6ca-4b31-85d3-1af878cc4676">
