### PR TITLE
chore: update package.json to add type module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "rslog",
   "version": "1.2.5",
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
This pull request updates the `package.json` file to align with modern JavaScript module standards. The changes ensure compatibility with both CommonJS and ES modules by adjusting the `main` field and the `exports` configuration.
