### PR TITLE
fix: merge `info` and `log` level

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,13 @@ logger.level = 'verbose';
 
 The log levels of each method are as follows:
 
-| Level   | Method                              |
-| ------- | ----------------------------------- |
-| silent  | No log will be output               |
-| error   | only `error` logs                   |
-| warn    | `warn`                              |
-| info    | `info`, `start`, `ready`, `success` |
-| log     | `log`                               |
-| verbose | `debug`                             |
+| Level      | Method                                              |
+| ---------- | --------------------------------------------------- |
+| silent     | No log will be output                               |
+| error      | only `error` logs                                   |
+| warn       | `warn`                                              |
+| info (log) | `info`, `start`, `ready`, `success`, `log`, `greet` |
+| verbose    | `debug`                                             |
 
 ## Override
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,8 +6,9 @@ export let LOG_LEVEL = {
   error: 0,
   warn: 1,
   info: 2,
-  log: 3,
-  verbose: 4,
+  // log is an alias of info
+  log: 2,
+  verbose: 3,
 } as const;
 
 export let LOG_TYPES = {
@@ -44,9 +45,8 @@ export let LOG_TYPES = {
     level: 'info',
     color: green,
   },
-  // Level log
   log: {
-    level: 'log',
+    level: 'info',
   },
   // Level debug
   debug: {

--- a/src/createLogger.ts
+++ b/src/createLogger.ts
@@ -5,7 +5,7 @@ import { isErrorStackMessage } from './utils';
 import type { Options, LogMessage, Logger, LogMethods } from './types';
 
 export let createLogger = (options: Options = {}) => {
-  let maxLevel = options.level || 'log';
+  let maxLevel = options.level || 'info';
 
   let log = (type: LogMethods, message?: LogMessage, ...args: string[]) => {
     if (LOG_LEVEL[LOG_TYPES[type].level] > LOG_LEVEL[maxLevel]) {

--- a/tests/__snapshots__/logger.test.ts.snap
+++ b/tests/__snapshots__/logger.test.ts.snap
@@ -3,6 +3,13 @@
 exports[`logger > should create new logger with info level correctly 1`] = `
 [
   [
+    "😊 Rslog v1.0.0
+",
+  ],
+  [
+    "this is a log message",
+  ],
+  [
     "error   this is a error message",
   ],
   [


### PR DESCRIPTION
Refines the logging system by consolidating the `log` level into the `info` level. The changes aim to simplify the logging hierarchy and improve clarity.
