### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Rslog provides both CommonJS and ESModule output and supports Node.js >= 14.
 
 ## Credits
 
-Rslog is built with [Modern.js](https://github.com/web-infra-dev/modern.js).
+Rslog is built with [Rslib](https://github.com/web-infra-dev/rslib).
 
 The color implementation of Rslog are modified from [alexeyraspopov/picocolors](https://github.com/alexeyraspopov/picocolors).
 


### PR DESCRIPTION
This pull request updates the project credits in the `README.md` file to accurately reflect the current dependencies.

Documentation update:

* Changed the credit to state that Rslog is built with `Rslib` instead of `Modern.js` in the `README.md` file.