### PR TITLE
chore: update tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "./src",
+    "outDir": "./dist",
     "target": "ES2023",
-    "lib": ["ESNext"],
-    "skipLibCheck": true,
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
     "declaration": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
     "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "types": ["@rstest/core/globals"],
-    "isolatedModules": true
+    "moduleResolution": "nodenext"
   },
-  "include": ["src"],
-  "exclude": ["**/node_modules"]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "target": "ES2023",
-    "types": ["node"],
+    "types": ["node", "@rstest/core/globals"],
     "lib": ["DOM", "ESNext"],
     "declaration": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

- Upgrade TypeScript to ^6.0.2.
- Replace the root `tsconfig.json` with the shared NodeNext configuration.
- Validate the change with `pnpm build` and `pnpm test`.

## Related Links

- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2