### PR TITLE
chore(infra): enable tsgo, publint, and prettier checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           run_install: true
 
-      - name: Install Playwright
-        run: npx playwright install
-
       - name: Run Lint
         run: pnpm run lint
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,11 @@
+# Ignore artifacts
+dist
+**/dist
+**/.rslib
+compiled
+**/compiled
+doc_build
+**/doc_build
+
+# ignore pnpm-lock
 pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,2 @@
-# Ignore artifacts
 dist
-**/dist
-**/.rslib
-compiled
-**/compiled
-doc_build
-**/doc_build
-
-# ignore pnpm-lock
 pnpm-lock.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,6 @@ dist/      # generated package output
 
 ## Code style
 
-- Use single quotes and existing Oxfmt conventions.
+- Use single quotes and existing format conventions.
 - Keep TypeScript strict-safe; avoid `any`.
 - Naming: camelCase (functions/files), PascalCase (types/classes).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Stack
+
+- Node.js `^20.19.0 || >=22.12.0`
+- `pnpm` single-package workspace
+- TypeScript pure ESM package
+- Build: `rslib` with tsgo declarations and publint
+- Test runner: `rstest`
+
+## Commands (run early)
+
+```bash
+# setup
+corepack enable && pnpm install
+
+# dev checks
+pnpm lint
+pnpm test
+
+# build / package
+pnpm build
+npm pack --dry-run
+```
+
+## Project structure
+
+```text
+src/       # logger source and public exports
+tests/     # rstest tests and snapshots
+preview/   # local manual preview that imports dist
+dist/      # generated package output
+```
+
+## Code style
+
+- Use single quotes and existing Oxfmt conventions.
+- Keep TypeScript strict-safe; avoid `any`.
+- Naming: camelCase (functions/files), PascalCase (types/classes).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.3",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rstackjs/rslog.git"
+    "url": "git+https://github.com/rstackjs/rslog.git"
   },
   "license": "MIT",
   "type": "module",
@@ -34,6 +34,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260615.1",
     "path-serializer": "^0.6.0",
     "prettier": "^3.8.4",
+    "rsbuild-plugin-publint": "^1.0.0",
     "strip-ansi": "^7.2.0",
     "supports-color": "^10.2.2",
     "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@rslint/core": "^0.6.1",
     "@rstest/core": "^0.10.4",
     "@types/node": "^24.13.2",
+    "@typescript/native-preview": "7.0.0-dev.20260615.1",
     "path-serializer": "^0.6.0",
     "prettier": "^3.8.4",
     "strip-ansi": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "rslib",
     "bump": "npx bumpp",
-    "lint": "rslint",
+    "lint": "rslint && prettier --check .",
+    "lint:write": "rslint --fix && prettier --write .",
     "dev": "rslib --watch",
     "preview": "node ./preview/index.ts",
     "test": "rstest"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rslib",
-    "bump": "npx bumpp",
+    "bump": "pnpx bumpp",
     "lint": "rslint && prettier --check .",
     "lint:write": "rslint --fix && prettier --write .",
     "dev": "rslib --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
+      rsbuild-plugin-publint:
+        specifier: ^1.0.0
+        version: 1.0.0(@rsbuild/core@2.0.14)
       strip-ansi:
         specifier: ^7.2.0
         version: 7.2.0
@@ -117,6 +120,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rsbuild/core@2.0.14':
     resolution: {integrity: sha512-SSPer6vM+v82CV6JXIOzyyT++A1ECgsVvvUuveD5rfGxX/W58vWGnB+zWcYbMfYOjTntD+9ve6QGGh6kBjPx6A==}
@@ -348,8 +355,18 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   path-serializer@0.6.0:
     resolution: {integrity: sha512-LlnjpuCARGnJ4X3IirMg0qozvqyTQHmM5ZqUDYmz+yanhjHSP5BqpmgHkOjiFHad9+bYNW9f5ECXv1tUyw2B9A==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -358,6 +375,11 @@ packages:
   prettier@3.8.4:
     resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
+    hasBin: true
+
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   rsbuild-plugin-dts@0.22.1:
@@ -375,6 +397,19 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  rsbuild-plugin-publint@1.0.0:
+    resolution: {integrity: sha512-QNu6zL0TOmFZfrCiKSmkw092jDhhPpiA1QYDRkvhkW1wDLowuVEYOqdV87Eo/I6geV0nuKKnCgLHT+Fevbz6pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -458,6 +493,8 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@publint/pack@0.1.4': {}
 
   '@rsbuild/core@2.0.14':
     dependencies:
@@ -642,11 +679,24 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  mri@1.2.0: {}
+
+  package-manager-detector@1.6.0: {}
+
   path-serializer@0.6.0: {}
+
+  picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
 
   prettier@3.8.4: {}
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   rsbuild-plugin-dts@0.22.1(@rsbuild/core@2.0.14)(@typescript/native-preview@7.0.0-dev.20260615.1)(typescript@6.0.3):
     dependencies:
@@ -655,6 +705,16 @@ snapshots:
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260615.1
       typescript: 6.0.3
+
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.14):
+    dependencies:
+      publint: 0.3.21
+    optionalDependencies:
+      '@rsbuild/core': 2.0.14
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   strip-ansi@7.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: ^0.22.1
-        version: 0.22.1(typescript@6.0.3)
+        version: 0.22.1(@typescript/native-preview@7.0.0-dev.20260615.1)(typescript@6.0.3)
       '@rslint/core':
         specifier: ^0.6.1
         version: 0.6.1
@@ -20,6 +20,9 @@ importers:
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260615.1
+        version: 7.0.0-dev.20260615.1
       path-serializer:
         specifier: ^0.6.0
         version: 0.6.0
@@ -290,6 +293,53 @@ packages:
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-EHrtoVGEEhIhsnGe+b8w0FoM9JfIw5SkoPwO8ifaU0PrYm2UbyPbj2I2hOTxtk458t0irvGz2+8cshylBRbKng==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-BcDA56hkk6mrUpysaOVvrdACoX5d2SF1JTwHMoNjT1KysBicExS2wlH0eN0L01iDeqtB73XHl7A4zrKFmKzrBg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-TDAlBpyYCF7Z+ELTH+1tabDE6W3shl+H+Z+nmzaQio1I8pFvbwt2iLlE0Rc9CpRdIeaqr0ppMEgXHoeV3fZFWA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-YRXRS/7ZqrDKXBJhFQcZiOdnHRuRbWoL/QkggpoGfhIuSAh4HvTU0WEUnPM+jRnH2kUMfsSgd8EAnPvmuP7/VA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-/QDmRWt6abB7fw3yMchjlyDXej/7Dr8mYG4wvGGf6c1hc5Il5UpDQWNHejatdeKvAu+sszz8JhTuL8et47fTTg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-WTJOLoe2rxT0W1i8ndWk2MKrakxRFNki537JZxvKAmSTbyOZznHlW3O3dbryUtTBYA716DDqS3ci24kuIfvBdg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-4cSCpXG7um18nwmLdU/SjoTv3OcO38/ufTiy1oWVccgGHLJqppiOP9/o+ElKIWhvrp78IaGy8+h3YqEjQ4/pcQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-JJ8X1l7H1GrnseK1k30qfQqB8Pz6jw3IALZVIj5oXQeRbUCe0Wx3ljkJEmOpunogdhEfA8IlOggskbUjVsXKBQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -416,10 +466,10 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.22.1(typescript@6.0.3)':
+  '@rslib/core@0.22.1(@typescript/native-preview@7.0.0-dev.20260615.1)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.14
-      rsbuild-plugin-dts: 0.22.1(@rsbuild/core@2.0.14)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.22.1(@rsbuild/core@2.0.14)(@typescript/native-preview@7.0.0-dev.20260615.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -557,6 +607,37 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260615.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260615.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260615.1
+
   ansi-regex@6.2.2: {}
 
   assertion-error@2.0.1: {}
@@ -567,11 +648,12 @@ snapshots:
 
   prettier@3.8.4: {}
 
-  rsbuild-plugin-dts@0.22.1(@rsbuild/core@2.0.14)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.1(@rsbuild/core@2.0.14)(@typescript/native-preview@7.0.0-dev.20260615.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.14
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260615.1
       typescript: 6.0.3
 
   strip-ansi@7.2.0:

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [{ syntax: 'es2023', dts: true }],
+  lib: [
+    {
+      syntax: 'es2023',
+      dts: {
+        tsgo: true,
+      },
+    },
+  ],
 });

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 
 export default defineConfig({
+  plugins: [pluginPublint()],
   lib: [
     {
       syntax: 'es2023',

--- a/src/createLogger.ts
+++ b/src/createLogger.ts
@@ -7,9 +7,7 @@ import type { Options, LogMessage, Logger, LogMethods } from './types.js';
 const normalizeErrorMessage = (err: Error) => {
   if (err.stack) {
     const [rawName, ...rest] = err.stack.split('\n');
-    const name = rawName.startsWith('Error: ')
-      ? rawName.slice(7)
-      : rawName;
+    const name = rawName.startsWith('Error: ') ? rawName.slice(7) : rawName;
     return `${name}\n${color.gray(rest.join('\n'))}`;
   }
 


### PR DESCRIPTION
## Summary

This PR was recreated from the latest `origin/main` on a new branch. It tightens the rslog infrastructure baseline without changing runtime behavior: Rslib declaration generation now uses tsgo, publint runs during build, linting includes JS recommended rules plus Prettier checks, agent guidance is documented, and the unused Playwright install step is removed from CI.

Notes:

- CI still uses the current Node 24 setup; no Node 20 matrix is added.
- No extra CI build step is added.
- Knip was used as a local dependency audit only and is not added as a project dependency.
