### PR TITLE
perf: cache formatted log labels

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,10 +16,17 @@ const createLogType = <T extends LogLevel>(
   label: string,
   level: T,
   style: ColorFn,
-) => ({
-  label: color.bold(style(label.padEnd(7))),
-  level,
-});
+) => {
+  let formattedLabel: string | undefined;
+
+  return {
+    // Defer styling until first access so runtime color settings are respected.
+    get label() {
+      return (formattedLabel ??= color.bold(style(label.padEnd(7))));
+    },
+    level,
+  };
+};
 
 export const LOG_TYPES = {
   error: createLogType('error', 'error', color.red),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import { color } from './color.js';
-import type { LogType } from './types.js';
+import type { ColorFn } from './color.js';
+import type { LogLevel, LogType } from './types.js';
 
 export const LOG_LEVEL = {
   silent: -1,
@@ -11,47 +12,24 @@ export const LOG_LEVEL = {
   verbose: 3,
 } as const;
 
+const createLogType = <T extends LogLevel>(
+  label: string,
+  level: T,
+  style: ColorFn,
+) => ({
+  label: color.bold(style(label.padEnd(7))),
+  level,
+});
+
 export const LOG_TYPES = {
-  // Level error
-  error: {
-    label: 'error',
-    level: 'error',
-    color: color.red,
-  },
-  // Level warn
-  warn: {
-    label: 'warn',
-    level: 'warn',
-    color: color.yellow,
-  },
-  // Level info
-  info: {
-    label: 'info',
-    level: 'info',
-    color: color.cyan,
-  },
-  start: {
-    label: 'start',
-    level: 'info',
-    color: color.cyan,
-  },
-  ready: {
-    label: 'ready',
-    level: 'info',
-    color: color.green,
-  },
-  success: {
-    label: 'success',
-    level: 'info',
-    color: color.green,
-  },
+  error: createLogType('error', 'error', color.red),
+  warn: createLogType('warn', 'warn', color.yellow),
+  info: createLogType('info', 'info', color.cyan),
+  start: createLogType('start', 'info', color.cyan),
+  ready: createLogType('ready', 'info', color.green),
+  success: createLogType('success', 'info', color.green),
   log: {
     level: 'info',
   },
-  // Level debug
-  debug: {
-    label: 'debug',
-    level: 'verbose',
-    color: color.magenta,
-  },
+  debug: createLogType('debug', 'verbose', color.magenta),
 } satisfies Record<string, LogType>;

--- a/src/createLogger.ts
+++ b/src/createLogger.ts
@@ -30,13 +30,8 @@ export const createLogger = (options: Options = {}) => {
       return console.log();
     }
 
-    let label = '';
+    const label = 'label' in logType ? logType.label : '';
     let text = '';
-
-    if ('label' in logType) {
-      label = (logType.label || '').padEnd(7);
-      label = color.bold(logType.color ? logType.color(label) : label);
-    }
 
     if (message instanceof Error) {
       text += normalizeErrorMessage(message);

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -23,6 +23,46 @@ const printTestLogs = (logger: Logger) => {
 };
 
 describe('logger', () => {
+  test('should respect color settings configured after import', async () => {
+    const originalForceColor = process.env.FORCE_COLOR;
+    const originalNoColor = process.env.NO_COLOR;
+    const originalDisableColors = process.env.NODE_DISABLE_COLORS;
+    const customConsole = {
+      log: rs.fn(),
+      warn: rs.fn(),
+      error: rs.fn(),
+    };
+
+    delete process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    delete process.env.NODE_DISABLE_COLORS;
+
+    try {
+      rs.resetModules();
+      const { createLogger: createConfiguredLogger } =
+        await import('../src/index.js');
+
+      process.env.FORCE_COLOR = '1';
+      createConfiguredLogger({ console: customConsole }).info('hello');
+
+      const output = (customConsole.log as Mock).mock.calls[0][0].toString();
+      expect(output).not.toBe(stripAnsi(output));
+    } finally {
+      const restoreEnv = (key: string, value: string | undefined) => {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      };
+
+      restoreEnv('FORCE_COLOR', originalForceColor);
+      restoreEnv('NO_COLOR', originalNoColor);
+      restoreEnv('NODE_DISABLE_COLORS', originalDisableColors);
+      rs.resetModules();
+    }
+  });
+
   test('should log as expected', () => {
     console.log = rs.fn();
     console.warn = rs.fn();

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -24,41 +24,24 @@ const printTestLogs = (logger: Logger) => {
 
 describe('logger', () => {
   test('should respect color settings configured after import', async () => {
-    const originalForceColor = process.env.FORCE_COLOR;
-    const originalNoColor = process.env.NO_COLOR;
-    const originalDisableColors = process.env.NODE_DISABLE_COLORS;
-    const customConsole = {
-      log: rs.fn(),
-      warn: rs.fn(),
-      error: rs.fn(),
-    };
-
-    delete process.env.FORCE_COLOR;
-    delete process.env.NO_COLOR;
-    delete process.env.NODE_DISABLE_COLORS;
+    rs.stubEnv('FORCE_COLOR', undefined);
+    rs.stubEnv('NO_COLOR', undefined);
+    rs.stubEnv('NODE_DISABLE_COLORS', undefined);
 
     try {
       rs.resetModules();
       const { createLogger: createConfiguredLogger } =
         await import('../src/index.js');
+      const log = rs.fn();
 
-      process.env.FORCE_COLOR = '1';
-      createConfiguredLogger({ console: customConsole }).info('hello');
+      rs.stubEnv('FORCE_COLOR', '1');
+      createConfiguredLogger({
+        console: { log, warn: rs.fn(), error: rs.fn() },
+      }).info('hello');
 
-      const output = (customConsole.log as Mock).mock.calls[0][0].toString();
-      expect(output).not.toBe(stripAnsi(output));
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('\x1b'));
     } finally {
-      const restoreEnv = (key: string, value: string | undefined) => {
-        if (value === undefined) {
-          delete process.env[key];
-        } else {
-          process.env[key] = value;
-        }
-      };
-
-      restoreEnv('FORCE_COLOR', originalForceColor);
-      restoreEnv('NO_COLOR', originalNoColor);
-      restoreEnv('NODE_DISABLE_COLORS', originalDisableColors);
+      rs.unstubAllEnvs();
       rs.resetModules();
     }
   });


### PR DESCRIPTION
## Summary

Logger labels are fixed, but they were padded and styled on every emitted labeled message. This PR introduces `createLogType` to lazily format each label on first access, respecting runtime color settings configured after import while reusing the result on subsequent logs.

## Benchmarks

Measured on macOS arm64 with Node 24.12.0 using dynamic messages, a retained no-op console, and seven-run medians.

| Metric | `main` | This PR | Difference |
| --- | ---: | ---: | ---: |
| `dist/index.js` | 4,719 B | 4,533 B | -3.9% |
| `dist/index.js` gzip | 1,588 B | 1,601 B | +0.8% |
| Non-TTY `info` | 365.7 ns | 36.1 ns | 10.1× faster |
| True-color `info` | 3,144 ns | 33.3 ns | 94.4× faster |
| True-color `warn` | 3,125.6 ns | 41.6 ns | 75.1× faster |
| True-color `error` | 3,250.3 ns | 127.4 ns | 25.5× faster |