### PR TITLE
fix: multiline prefix alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "strip-ansi": "^7.2.0",
     "typescript": "^7.0.2"
   },
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.11.0",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },

--- a/src/createLogger.ts
+++ b/src/createLogger.ts
@@ -3,8 +3,6 @@ import { LOG_LEVEL, LOG_TYPES } from './constants.js';
 import { isErrorStackMessage, stripAnsi } from './utils.js';
 import type { Options, LogMessage, Logger, LogMethods } from './types.js';
 
-const LABEL_WIDTH = 7;
-
 const normalizeErrorMessage = (err: Error) => {
   if (err.stack) {
     const [rawName, ...rest] = err.stack.split('\n');
@@ -38,8 +36,8 @@ export const createLogger = (options: Options = {}) => {
     }
 
     const label = 'label' in logType ? logType.label : '';
+    const header = label ? (prefix ? `${label} ${prefix}` : label) : prefix;
     let text = '';
-    const hasLabel = Boolean(label);
 
     const isErrorObject = message instanceof Error;
 
@@ -63,14 +61,8 @@ export const createLogger = (options: Options = {}) => {
       text = `${message}`;
     }
 
-    if (prefix) {
-      text = `${prefix} ${text}`;
-    }
-
-    if (alignMultiline && hasLabel && !isErrorObject && text.includes('\n')) {
-      const indent = ' '.repeat(
-        LABEL_WIDTH + 1 + (prefix ? stripAnsi(prefix).length + 1 : 0),
-      );
+    if (alignMultiline && header && !isErrorObject && text.includes('\n')) {
+      const indent = ' '.repeat(stripAnsi(header).length + 1);
       const skipStack = level === 'error';
       text = text
         .split('\n')
@@ -83,7 +75,7 @@ export const createLogger = (options: Options = {}) => {
     }
 
     const method = level === 'error' || level === 'warn' ? level : 'log';
-    console[method](label ? `${label} ${text}` : text, ...args);
+    console[method](header ? `${header} ${text}` : text, ...args);
   };
 
   const logger = {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -304,6 +304,22 @@ describe('logger', () => {
     ).toMatchSnapshot();
   });
 
+  test('should align multi-line log messages to prefix column', () => {
+    console.log = rs.fn();
+
+    const alignLogger = createLogger({
+      alignMultiline: true,
+      prefix: '[web]',
+    });
+
+    alignLogger.log(`First line
+Second line`);
+
+    expect(stripAnsi((console.log as Mock).mock.calls[0][0].toString()))
+      .toBe(`[web] First line
+      Second line`);
+  });
+
   test('should keep error stacks top-aligned when alignMultiline is enabled', () => {
     console.error = rs.fn();
 


### PR DESCRIPTION
This PR fixes continuation-line alignment for label-less logger methods with a prefix by deriving both rendering and indentation from the same header.

It also pins pnpm to 11.11.0 because the 11.13.0 standalone platform package omits its executable and breaks local installs. This follows up on #94 and adds regression coverage for `logger.log()` with `alignMultiline` enabled.